### PR TITLE
Disable asset request logging in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "select2-rails", "3.5.5"
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
+  gem "quiet_assets", "1.1.0"
   gem "railroady"
   gem "rubocop"
   gem "thin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.5.2)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -334,6 +336,7 @@ DEPENDENCIES
   paper_trail (>= 3.0.0.beta1)
   plek (>= 1.0.0)
   pry-rails
+  quiet_assets (= 1.1.0)
   railroady
   rails (= 4.0.5)
   rspec-rails (~> 2.14)


### PR DESCRIPTION
These lines make the log really noisy. We use it successfully in quite a few apps: https://github.com/search?q=user%3Aalphagov+quiet_assets&type=Code&utf8=%E2%9C%93