### PR TITLE
Use Rummager in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ alternatively you can load the database schema and use the old initial seed data
 
 Start the application with `./startup.sh` or use bowler.
 
-Set RUMMAGER_API=true and WHITEHALL_API=true to enable API requests in development
-
 open http://contacts.dev.gov.uk/contact/hm-revenue-customs/
 open http://contacts.dev.gov.uk/admin
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,10 +39,6 @@ Contacts::Application.configure do
 
     Contacts.worldwide_api = GdsApi::Worldwide.new( Plek.current.find('whitehall-admin') )
 
-    Contacts.rummager_client = if ENV['RUMMAGER_API']
-      Rummageable::Index.new( Plek.current.find('search'), 'mainstream', logger: Rails.logger )
-    else
-      FakeRummageableIndex.new("http://localhost", 'mainstream', logger: Rails.logger)
-    end
+    Contacts.rummager_client = Rummageable::Index.new( Plek.current.find('search'), 'mainstream', logger: Rails.logger )
   end
 end


### PR DESCRIPTION
Reduces complexity.

If integration with Rummager were to be broken, we want to know before we deploy
it to preview/production.

The comment about WHITEHALL_API was out of date.