### PR TITLE
Fix broken frontend assets

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,12 +1,6 @@
 class AdminController < ApplicationController
   layout "admin"
 
-  # Don't serve admin assets from the CDN
-  # Respond.js needs to run on the same domain to request stylesheets,
-  # parse them and render a non-mobile layout on <IE9
-  # https://github.com/scottjehl/Respond#cdnx-domain-setup
-  ActionController::Base.asset_host = nil
-
   prepend_before_filter :authenticate_user!
   before_filter :require_signin_permission!
   before_filter :skip_slimmer

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,8 +30,13 @@ Contacts::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # FIXME: Stop setting asset_host when we split the frontend off into a finder
   if ENV['GOVUK_ASSET_ROOT'].present?
-    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+    config.asset_host = Proc.new do |source, request, *_|
+      unless request.original_fullpath.start_with?('/admin')
+        ENV['GOVUK_ASSET_HOST']
+      end
+    end
   end
 
   config.after_initialize do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,14 @@ Contacts::Application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
+  # Use a separate asset host for public-facing requests, but not for requests
+  # to the admin pages.
+  # FIXME: Stop setting asset_host when we split the frontend off into a finder
+  config.action_controller.asset_host = Proc.new do |source, request, *_|
+    unless request.original_fullpath.start_with?('/admin')
+      ENV['GOVUK_ASSET_HOST']
+    end
+  end
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
Setting the asset_host to nil in the admin controller was intended to only
apply to admin, but actually applied to frontend too. This meant that in
production-like environments, the links to stylesheets didn't work.

I copied the technique from here:
http://stackoverflow.com/a/10252239